### PR TITLE
Remove python 3.2 and nighlty from travis environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,8 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
-  - "nightly"
 
 env: LIBGIT2=~/libgit2/_install/ LD_LIBRARY_PATH=~/libgit2/_install/lib
 

--- a/fresque/utils.py
+++ b/fresque/utils.py
@@ -6,7 +6,7 @@ Some Flask-specific utility functions.
 
 from __future__ import absolute_import, unicode_literals, print_function
 
-import urlparse
+from six.moves import urllib_parse as urlparse
 
 import flask
 from six import string_types


### PR DESCRIPTION
Most of the packages doesn't support dependency for these two version.