### PR TITLE
Explicitly import fresque.exceptions

### DIFF
--- a/fresque/lib/views.py
+++ b/fresque/lib/views.py
@@ -18,6 +18,7 @@ import os
 import pygit2
 import json
 import fresque
+import fresque.exceptions
 from time import time
 
 from sqlalchemy.exc import SQLAlchemyError


### PR DESCRIPTION
Without this change, adding a new package as the first thing attempted on a
freshly started server fails with an AttributeError looking for the exceptions
submodule of the fresque package.